### PR TITLE
Swap processed and failed numbers in the stats

### DIFF
--- a/ui/api.js
+++ b/ui/api.js
@@ -120,8 +120,8 @@ async function enqueue(request) {
 async function stats(request) {
   const stats = await Promise.all([
     Stats.active,
-    Stats.failed,
     Stats.processed,
+    Stats.failed,
     Stats.enqueued,
   ]).spread((active, processed, failed, enqueued) => ({
     processed,


### PR DESCRIPTION
The current api mistakenly sends the number of failed jobs as processed ones and vice versa.