### PR TITLE
Fix the route for deleting jobs with a status

### DIFF
--- a/ui/server.js
+++ b/ui/server.js
@@ -22,7 +22,7 @@ function server(port) {
 
   // API
   app.get('/api/jobs', api.jobs);
-  app.delete('/api/jobs/:status', api.removeJobs);
+  app.delete('/api/jobs/status/:status', api.removeJobs);
   app.get('/api/jobs/:jid', api.job);
   app.delete('/api/jobs/:jid', api.remove);
   app.post('/api/jobs/:jid/retry', api.retry);


### PR DESCRIPTION
Currently, we can't remove a given job because the route for deleting jobs with a status covers the route for deleting a single job.